### PR TITLE
Updated readme and codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @chrisdavis180
+*       @cdavis-personal

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -16,13 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Ruby 2.6
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+    - name: Set up Ruby 3.0.0
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 3.0.0
 
     - name: Publish to GPR
       run: |

--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -16,10 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Ruby 3.0.0
+    - name: Set up Ruby 3.0
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.0.0
+        ruby-version: 3.x.x
 
     - name: Publish to GPR
       run: |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # ZephyrRuby
 
-[Zephyr REST API Documentation](https://support.smartbear.com/zephyr-scale-cloud/api-docs/#section/Introduction)
-
 ## Installation
 
 Install the gem and add to the application's Gemfile by executing:

--- a/zephyr_ruby.gemspec
+++ b/zephyr_ruby.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.summary     = 'Zephyr REST API Client for Ruby'
   spec.description = "Allows users to use Zephyr's REST API"
   spec.license     = 'MIT'
-  spec.required_ruby_version = '>= 3.0'
+  spec.required_ruby_version = '>= 3'
   spec.homepage = 'https://github.com/cdavis-personal/zephyr_ruby'
 
   spec.files = Dir.chdir(__dir__) do

--- a/zephyr_ruby.gemspec
+++ b/zephyr_ruby.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.summary     = 'Zephyr REST API Client for Ruby'
   spec.description = "Allows users to use Zephyr's REST API"
   spec.license     = 'MIT'
-  spec.required_ruby_version = '>= 3'
+  spec.required_ruby_version = '>= 3.0'
   spec.homepage = 'https://github.com/cdavis-personal/zephyr_ruby'
 
   spec.files = Dir.chdir(__dir__) do


### PR DESCRIPTION
This pull request includes several updates to the repository. The most important changes involve updating the code owners, modifying the Ruby setup in the GitHub Actions workflow, and cleaning up the `README.md` file.

Updates to code owners:

* [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7L8-R8): Changed the code owner from `@chrisdavis180` to `@cdavis-personal`.

Modifications to GitHub Actions workflow:

* [`.github/workflows/gem-push.yml`](diffhunk://#diff-833c02c4c574210e7f4b244d039a514a229ee733c42f8771d2f3b6cfd4ceb481L19-R22): Updated the Ruby version setup from 2.6 to 3.0 and switched to using the latest `ruby/setup-ruby` action.

Cleanup in `README.md`:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-L4): Removed an outdated link to the Zephyr REST API Documentation.